### PR TITLE
Ajout de month_unique_user_count

### DIFF
--- a/scripts/refresh_materialized_view.sql
+++ b/scripts/refresh_materialized_view.sql
@@ -2,3 +2,4 @@
 REFRESH MATERIALIZED VIEW CONCURRENTLY user_monthly_visits;
 REFRESH MATERIALIZED VIEW daily_unique_user_count;
 REFRESH MATERIALIZED VIEW unique_user_daily_count_30d;
+REFRESH MATERIALIZED VIEW month_unique_user_count;

--- a/scripts/tables.sql
+++ b/scripts/tables.sql
@@ -167,3 +167,51 @@ SELECT
   unique_user_count
 FROM
   unique_users_per_day;
+  
+  
+# monthly_unique_user_count
+CREATE MATERIALIZED VIEW IF NOT EXISTS monthly_unique_user_count AS
+SELECT
+  date_trunc('month', visit_ts) AS month,
+  user_id,
+  instance,
+  domain,
+  COUNT(*) AS visits_count,
+  COUNT(CASE
+    WHEN user_agent LIKE 'Mozilla%' THEN 1
+    ELSE NULL
+  END) AS web_visits_count,
+  COUNT(CASE
+    WHEN user_agent LIKE 'Tchap%Android%' OR
+         user_agent LIKE 'RiotNSE/2%iOS%' OR
+         user_agent LIKE 'RiotSharedExtension/2%iOS%' OR
+         user_agent LIKE 'Tchap%iOS%' OR
+         user_agent LIKE 'Riot%iOS' OR
+         user_agent LIKE 'Riot%Android' OR
+         user_agent LIKE 'Element%Android' OR
+         user_agent LIKE 'Element%iOS'
+    THEN 1
+    ELSE NULL
+  END) AS mobile_visits_count,
+  COUNT(CASE
+    WHEN user_agent NOT LIKE 'Mozilla%' AND
+         user_agent NOT LIKE 'Tchap%Android%' AND
+         user_agent NOT LIKE 'RiotNSE/2%iOS%' AND
+         user_agent NOT LIKE 'RiotSharedExtension/2%iOS%' AND
+         user_agent NOT LIKE 'Tchap%iOS%' AND
+         user_agent NOT LIKE 'Riot%iOS' AND
+         user_agent NOT LIKE 'Riot%Android' AND
+         user_agent NOT LIKE 'Element%Android' AND
+         user_agent NOT LIKE 'Element%iOS'
+    THEN 1
+    ELSE NULL
+  END) AS other_visits_count
+FROM
+  user_daily_visits
+GROUP BY
+  date_trunc('month', visit_ts),
+  user_id,
+  instance,
+  domain;
+  
+CREATE INDEX IF NOT EXISTS idx_month_unique_user_count_day ON month_unique_user_count(month);


### PR DESCRIPTION
# Problème
La table user_monthly_visit contient une ligne par appareil. Pour calculer, le nombre de visite sur 1 mois, il faut faire un "GROUP BY user_id" cette opération est couteuse et échoue dans metabase

# Solution
Nouvelle table month_unique_user_count avec une ligne par utilisateur par mois.
Cela permet de calculer des totaux d'utilisateurs actifs par mois beaucoup rapidement et de filtrer si besoin les données par catégorie.

# Nodes
Test en cours sur la DB de stats