### PR TITLE
pushers aggregate - ajouter une date d'ajout

### DIFF
--- a/scripts/tables.sql
+++ b/scripts/tables.sql
@@ -141,15 +141,20 @@ CREATE TABLE IF NOT EXISTS pushers_aggregate (
   kind VARCHAR ,
   is_enabled BOOLEAN,
   instance VARCHAR NOT NULL,
-  domain VARCHAR NOT NULL
+  domain VARCHAR NOT NULL,
+  added_date DATE NOT NULL DEFAULT current_date   -- new column to store added date
 );
 
-CREATE INDEX IF NOT EXISTS pushers_aggregate_domain_idx ON pushers_aggregate (domain);
+/* this unique index is optimized to group on date/kind */
+CREATE UNIQUE INDEX IF NOT EXISTS pushers_aggregate_unique ON pushers_aggregate (added_date, kind, app_id,device_id);
 CREATE INDEX IF NOT EXISTS pushers_aggregate_kind_idx ON pushers_aggregate (kind);
+
+/*
+CREATE INDEX IF NOT EXISTS pushers_aggregate_domain_idx ON pushers_aggregate (domain);
 CREATE INDEX IF NOT EXISTS pushers_aggregate_is_enabled_idx ON pushers_aggregate (is_enabled);
 CREATE INDEX IF NOT EXISTS pushers_aggregate_app_id_idx ON pushers_aggregate (app_id);
 CREATE INDEX IF NOT EXISTS pushers_aggregate_instance_idx ON pushers_aggregate (instance);
-
+*/
 
 
 


### PR DESCRIPTION
- table has been wiped and recreated with a new column and index

CREATE TABLE IF NOT EXISTS pushers_aggregate (
  user_name VARCHAR NOT NULL,
  device_id VARCHAR NOT NULL,
  app_id VARCHAR,
  kind VARCHAR ,
  is_enabled BOOLEAN,
  instance VARCHAR NOT NULL,
  domain VARCHAR NOT NULL,
  added_date DATE NOT NULL DEFAULT current_date   -- new column to store added date
);
