### PR TITLE
Use visit date in views

### DIFF
--- a/scripts/data_quality/check_coherence_user_monthly_visits_lite.sql
+++ b/scripts/data_quality/check_coherence_user_monthly_visits_lite.sql
@@ -1,0 +1,44 @@
+WITH original_visits AS (
+  -- Première requête sur user_monthly_visits_lite
+  SELECT
+    DATE_TRUNC('month', "public"."user_monthly_visits_lite"."visit_ts") AS "month",
+    COUNT(DISTINCT "public"."user_monthly_visits_lite"."user_id") AS "user_count_original"
+  FROM
+    "public"."user_monthly_visits_lite"
+  WHERE
+    "public"."user_monthly_visits_lite"."visit_ts" >= DATE_TRUNC('month', NOW() + INTERVAL '-12 month')
+    AND "public"."user_monthly_visits_lite"."visit_ts" < DATE_TRUNC('month', NOW())
+  GROUP BY
+    DATE_TRUNC('month', "public"."user_monthly_visits_lite"."visit_ts")
+),
+
+v2_visits AS (
+  -- Deuxième requête sur user_daily_visits_by_month_1y_v3
+  SELECT
+    DATE_TRUNC('month', "public"."user_daily_visits_by_month_1y_v3"."month") AS "month",
+    COUNT(DISTINCT "public"."user_daily_visits_by_month_1y_v3"."user_id") AS "user_count_v2"
+  FROM
+    "public"."user_daily_visits_by_month_1y_v3"
+  WHERE
+    "public"."user_daily_visits_by_month_1y_v3"."month" >= DATE_TRUNC('month', NOW() + INTERVAL '-12 month')
+    AND "public"."user_daily_visits_by_month_1y_v3"."month" < DATE_TRUNC('month', NOW())
+    AND (
+      "public"."user_daily_visits_by_month_1y_v3"."platform" <> 'Autre'
+      OR "public"."user_daily_visits_by_month_1y_v3"."platform" IS NULL
+    )
+  GROUP BY
+    DATE_TRUNC('month', "public"."user_daily_visits_by_month_1y_v3"."month")
+)
+
+-- Jointure des résultats des deux requêtes sur le mois et calcul de différence
+SELECT 
+  COALESCE(original_visits.month, v2_visits.month) AS month,  -- Garder le mois même s'il n'existe que dans une des tables
+  COALESCE(original_visits.user_count_original, 0) AS user_count_original,  -- Utilisateurs distincts dans la première table
+  COALESCE(v2_visits.user_count_v2, 0) AS user_count_v2,  -- Utilisateurs distincts dans la seconde table
+  (COALESCE(v2_visits.user_count_v2, 0) - COALESCE(original_visits.user_count_original, 0)) AS user_count_difference  -- Calcul de la différence
+FROM 
+  original_visits
+FULL OUTER JOIN v2_visits 
+  ON original_visits.month = v2_visits.month  -- Jointure sur le mois
+ORDER BY 
+  COALESCE(original_visits.month, v2_visits.month) ASC;  -- Tri des résultats

--- a/scripts/data_quality/migration_user_daily_visits_by_month_18m_v2.sql
+++ b/scripts/data_quality/migration_user_daily_visits_by_month_18m_v2.sql
@@ -1,0 +1,47 @@
+WITH original_visits AS (
+  -- Première requête sur user_daily_visits_by_month_18m
+  SELECT
+    DATE_TRUNC('month', "public"."user_daily_visits_by_month_18m"."month") AS "month",
+    COUNT(DISTINCT "public"."user_daily_visits_by_month_18m"."user_id") AS "user_count_original"
+  FROM
+    "public"."user_daily_visits_by_month_18m"
+  WHERE
+    "public"."user_daily_visits_by_month_18m"."month" >= DATE_TRUNC('month', NOW() + INTERVAL '-12 month')
+    AND "public"."user_daily_visits_by_month_18m"."month" < DATE_TRUNC('month', NOW())
+    AND (
+      "public"."user_daily_visits_by_month_18m"."platform" <> 'Autre'
+      OR "public"."user_daily_visits_by_month_18m"."platform" IS NULL
+    )
+  GROUP BY
+    DATE_TRUNC('month', "public"."user_daily_visits_by_month_18m"."month")
+),
+
+v2_visits AS (
+  -- Deuxième requête sur user_daily_visits_by_month_18m_v2
+  SELECT
+    DATE_TRUNC('month', "public"."user_daily_visits_by_month_18m_v2"."month") AS "month",
+    COUNT(DISTINCT "public"."user_daily_visits_by_month_18m_v2"."user_id") AS "user_count_v2"
+  FROM
+    "public"."user_daily_visits_by_month_18m_v2"
+  WHERE
+    "public"."user_daily_visits_by_month_18m_v2"."month" >= DATE_TRUNC('month', NOW() + INTERVAL '-12 month')
+    AND "public"."user_daily_visits_by_month_18m_v2"."month" < DATE_TRUNC('month', NOW())
+    AND (
+      "public"."user_daily_visits_by_month_18m_v2"."platform" <> 'Autre'
+      OR "public"."user_daily_visits_by_month_18m_v2"."platform" IS NULL
+    )
+  GROUP BY
+    DATE_TRUNC('month', "public"."user_daily_visits_by_month_18m_v2"."month")
+)
+
+-- Jointure des résultats des deux requêtes avec calcul de différence
+SELECT 
+  original_visits.month,
+  COALESCE(original_visits.user_count_original, 0) AS user_count_original,   -- Résultats de la première requête
+  COALESCE(v2_visits.user_count_v2, 0) AS user_count_v2,                      -- Résultats de la deuxième requête
+  (COALESCE(original_visits.user_count_original, 0) - COALESCE(v2_visits.user_count_v2, 0)) AS user_count_difference  -- Calcul de la différence
+FROM 
+  original_visits
+FULL OUTER JOIN v2_visits ON original_visits.month = v2_visits.month          -- Jointure sur "month"
+ORDER BY 
+  original_visits.month ASC;

--- a/scripts/data_quality/migration_user_daily_visits_by_month_1y_v2.sql
+++ b/scripts/data_quality/migration_user_daily_visits_by_month_1y_v2.sql
@@ -1,0 +1,47 @@
+WITH original_visits AS (
+  -- Première requête sur user_daily_visits_by_month_1y
+  SELECT
+    DATE_TRUNC('month', "public"."user_daily_visits_by_month_1y"."month") AS "month",
+    COUNT(DISTINCT "public"."user_daily_visits_by_month_1y"."user_id") AS "user_count_original"
+  FROM
+    "public"."user_daily_visits_by_month_1y"
+  WHERE
+    "public"."user_daily_visits_by_month_1y"."month" >= DATE_TRUNC('month', NOW() + INTERVAL '-12 month')
+    AND "public"."user_daily_visits_by_month_1y"."month" < DATE_TRUNC('month', NOW())
+    AND (
+      "public"."user_daily_visits_by_month_1y"."platform" <> 'Autre'
+      OR "public"."user_daily_visits_by_month_1y"."platform" IS NULL
+    )
+  GROUP BY
+    DATE_TRUNC('month', "public"."user_daily_visits_by_month_1y"."month")
+),
+
+v2_visits AS (
+  -- Deuxième requête sur user_daily_visits_by_month_1y_v2
+  SELECT
+    DATE_TRUNC('month', "public"."user_daily_visits_by_month_1y_v2"."month") AS "month",
+    COUNT(DISTINCT "public"."user_daily_visits_by_month_1y_v2"."user_id") AS "user_count_v2"
+  FROM
+    "public"."user_daily_visits_by_month_1y_v2"
+  WHERE
+    "public"."user_daily_visits_by_month_1y_v2"."month" >= DATE_TRUNC('month', NOW() + INTERVAL '-12 month')
+    AND "public"."user_daily_visits_by_month_1y_v2"."month" < DATE_TRUNC('month', NOW())
+    AND (
+      "public"."user_daily_visits_by_month_1y_v2"."platform" <> 'Autre'
+      OR "public"."user_daily_visits_by_month_1y_v2"."platform" IS NULL
+    )
+  GROUP BY
+    DATE_TRUNC('month', "public"."user_daily_visits_by_month_1y_v2"."month")
+)
+
+-- Jointure des résultats des deux requêtes avec calcul de différence
+SELECT 
+  original_visits.month,
+  COALESCE(original_visits.user_count_original, 0) AS user_count_original,   -- Résultats de la première requête
+  COALESCE(v2_visits.user_count_v2, 0) AS user_count_v2,                      -- Résultats de la deuxième requête
+  (COALESCE(original_visits.user_count_original, 0) - COALESCE(v2_visits.user_count_v2, 0)) AS user_count_difference  -- Calcul de la différence
+FROM 
+  original_visits
+FULL OUTER JOIN v2_visits ON original_visits.month = v2_visits.month          -- Jointure sur "month"
+ORDER BY 
+  original_visits.month ASC;

--- a/scripts/data_quality/migration_user_daily_visits_by_month_1y_v2_by_device_type.sql
+++ b/scripts/data_quality/migration_user_daily_visits_by_month_1y_v2_by_device_type.sql
@@ -1,0 +1,37 @@
+WITH results_12m AS (
+  SELECT
+    "public"."user_daily_visits_by_month_1y"."device_type" AS "device_type",
+    COUNT(DISTINCT "public"."user_daily_visits_by_month_1y"."device_id") AS "count_12m"
+  FROM
+    "public"."user_daily_visits_by_month_1y"
+  WHERE
+    "public"."user_daily_visits_by_month_1y"."month" >= DATE_TRUNC('month', (NOW() + INTERVAL '-1 month'))
+    AND "public"."user_daily_visits_by_month_1y"."month" < DATE_TRUNC('month', NOW())
+  GROUP BY
+    "public"."user_daily_visits_by_month_1y"."device_type"
+),
+
+results_v2 AS (
+  SELECT
+    "public"."user_daily_visits_by_month_1y_v2"."device_type" AS "device_type",
+    COUNT(DISTINCT "public"."user_daily_visits_by_month_1y_v2"."device_id") AS "count_v2"
+  FROM
+    "public"."user_daily_visits_by_month_1y_v2"
+  WHERE
+    "public"."user_daily_visits_by_month_1y_v2"."month" >= DATE_TRUNC('month', (NOW() + INTERVAL '-1 month'))
+    AND "public"."user_daily_visits_by_month_1y_v2"."month" < DATE_TRUNC('month', NOW())
+  GROUP BY
+    "public"."user_daily_visits_by_month_1y_v2"."device_type"
+)
+
+-- Comparer les résultats des deux requêtes avec une jointure sur "device_type"
+SELECT 
+  COALESCE(r12m."device_type", rV2."device_type") AS "device_type",  -- Garder le device_type, même s’il est null dans l’une des tables
+  COALESCE(r12m."count_12m", 0) AS "count_12m",                      -- Nombre de devices dans la première table (12 mois)
+  COALESCE(rV2."count_v2", 0) AS "count_v2",                         -- Nombre de devices dans la deuxième table (version V2)
+  (COALESCE(rV2."count_v2", 0) - COALESCE(r12m."count_12m", 0)) AS "Ecart"  -- Calcul de la différence
+FROM 
+  results_12m r12m
+FULL OUTER JOIN results_v2 rV2 ON r12m."device_type" = rV2."device_type"
+ORDER BY 
+  (COALESCE(rV2."count_v2", 0) - COALESCE(r12m."count_12m", 0)) DESC;

--- a/scripts/tables.sql
+++ b/scripts/tables.sql
@@ -56,6 +56,8 @@ ADD COLUMN visit_date DATE;
 
 CREATE UNIQUE INDEX IF NOT EXISTS unique_user_daily_idx ON user_daily_visits (user_id, device_id, visit_ts);
 CREATE INDEX IF NOT EXISTS user_daily_visits_visit_ts_desc_idx ON user_daily_visits (visit_ts DESC);
+CREATE INDEX IF NOT EXISTS user_daily_visits_visit_date_desc_idx ON user_daily_visits (visit_ts DESC);
+
 /* test index to speed up invalid data retrieval */ 
 CREATE INDEX IF NOT EXISTS user_daily_visits_platform_null_idx ON user_daily_visits (platform) WHERE platform IS NULL;
 

--- a/scripts/user_daily_visits_by_month_1y_v3.sql
+++ b/scripts/user_daily_visits_by_month_1y_v3.sql
@@ -1,0 +1,40 @@
+/*
+   vue matérialisée qui agrege les données de user_daily_visits par device et par  utilisateur et par mois
+   utilisée par le dashboard public
+   - la difference avec la V2 est que le champs visit_date (de type date, sans timezone) est utilisé à la place de visit_ts (timestamp avec timezone)
+
+*/
+/* DROP MATERIALIZED VIEW IF EXISTS user_daily_visits_by_month_1y_v3; */
+
+/** User Monthly Visits **/
+CREATE MATERIALIZED VIEW IF NOT EXISTS user_daily_visits_by_month_1y_v3 AS
+SELECT 
+  device_id,
+  date_trunc('month', visit_date) as month,
+  user_id,
+  instance,
+  domain,
+  device_type,
+  platform
+FROM user_daily_visits
+WHERE 
+  visit_date >= NOW() - INTERVAL '1 year' /* only one year */ 
+GROUP BY 
+  device_id, 
+  month, 
+  user_id, 
+  instance, 
+  domain, 
+  device_type, 
+  platform,
+  user_agent;
+
+CREATE INDEX IF NOT EXISTS user_daily_visits_by_month_1y_v3_month ON user_daily_visits_by_month_1y_v3 (month);
+CREATE INDEX IF NOT EXISTS user_daily_visits_by_month_1y_v3_device_id ON user_daily_visits_by_month_1y_v3 (device_id);
+CREATE INDEX IF NOT EXISTS user_daily_visits_by_month_1y_v3_user_id ON user_daily_visits_by_month_1y_v3 (user_id);
+CREATE INDEX IF NOT EXISTS user_daily_visits_by_month_1y_v3_instance ON user_daily_visits_by_month_1y_v3 (instance);
+CREATE INDEX IF NOT EXISTS user_daily_visits_by_month_1y_v3_domain ON user_daily_visits_by_month_1y_v3 (domain);
+CREATE INDEX IF NOT EXISTS user_daily_visits_by_month_1y_v3_device_type ON user_daily_visits_by_month_1y_v3 (device_type);
+CREATE INDEX IF NOT EXISTS user_daily_visits_by_month_1y_v3_platform ON user_daily_visits_by_month_1y_v3 (platform);
+
+REFRESH MATERIALIZED VIEW user_daily_visits_by_month_1y_v3; 

--- a/scripts/user_monthly_visits_lite_init.sql
+++ b/scripts/user_monthly_visits_lite_init.sql
@@ -54,3 +54,22 @@ WHERE udv.visit_ts >= '2024-01-01'
   AND udv.visit_ts < '2025-01-01'
   AND udv.device_type <> 'Autre'
 ON CONFLICT (user_id, visit_ts) DO NOTHING;
+
+/* remove data for 2024 */ 
+DELETE * 
+FROM user_monthly_visits_lite
+WHERE user_monthly_visits_lite.visit_ts >= '2024-01-01'
+  AND user_monthly_visits_lite.visit_ts < '2025-01-01'
+
+/* add data for year 2024 based on visit_date instead of visit_ts*/
+INSERT INTO user_monthly_visits_lite (user_id, visit_ts, instance, domain)
+SELECT DISTINCT ON (user_id, DATE_TRUNC('month', visit_date))
+    user_id, 
+    DATE_TRUNC('month', visit_date) AS visit_date, 
+    instance, 
+    domain
+FROM user_daily_visits udv
+WHERE udv.visit_date >= '2024-01-01'
+  AND udv.visit_date < '2025-01-01'
+  AND udv.device_type <> 'Autre'
+ON CONFLICT (user_id, visit_ts) DO NOTHING;


### PR DESCRIPTION
en utilisant le champs visit_ts qui possède une timezone, les requetes d'aggregation ne renvoient pas les meme resultats selon la timezone du client psql. 

Cette requete renvoit 270223 records depuis mon mac et 268647 depuis le serveur scalingo. En cause la différence de timezone et la fonction DATE_TRUNC() sur le champs visit_ts : certain records partent dans le mois N-1.

En effet les records que nous recevons du cloud PI sont tronqué au jour à minuit 0:00 avec une timezone. Au moment du DATE_TRUNC('month') , certains vont passer à une heure de moins, donc le jour d'avant, donc le mois d'avant.

```
SELECT COUNT(DISTINCT subquery.user_id) AS distinct_user_count
FROM(
	SELECT DISTINCT ON (user_id, DATE_TRUNC('month', visit_ts))
	    user_id, 
	    DATE_TRUNC('month', visit_ts) AS visit_ts, 
	    instance, 
	    domain
	FROM user_daily_visits udv
	WHERE udv.visit_ts >= (now() - '3 month'::interval)
	  AND udv.device_type <> 'Autre'
	) as subquery
WHERE 
	subquery.visit_ts >= '2024-10-01'                             -- Commence à partir du 1er octobre 2024
    AND subquery.visit_ts < '2024-11-01';  
```
