### PR TITLE
93 account data aggregate pipeline is broken

### DIFF
--- a/scripts/tables.sql
+++ b/scripts/tables.sql
@@ -94,7 +94,7 @@ CREATE TABLE IF NOT EXISTS account_data_aggregate (
 );
 
 /* create a unique index to avoid duplicates when importing data */
-CREATE INDEX IF NOT EXISTS unique_account_data_aggregate_idx ON account_data_aggregate (user_id, account_data_type);
+CREATE UNIQUE INDEX IF NOT EXISTS account_data_aggregate_pk ON account_data_aggregate (user_id, account_data_type);
 CREATE INDEX IF NOT EXISTS account_data_aggregate_domain_idx ON account_data_aggregate (domain);
 CREATE INDEX IF NOT EXISTS account_data_aggregate_type_idx ON account_data_aggregate (account_data_type);
 CREATE INDEX IF NOT EXISTS account_data_aggregate_instance_idx ON account_data_aggregate (instance);


### PR DESCRIPTION
Randomly deduplicate data when multiple values are present in the export.

This does fix does not guarantee that the account data aggregate stores the last value of the account data. 

It is sufficient for the current use og the account data aggrgate table.

It would be better to keep the last value, to this end, it is necessary to use a timestamp when exporting the data